### PR TITLE
Ensure obter_parlamentar returns None if not found

### DIFF
--- a/legislei/houses/alesp.py
+++ b/legislei/houses/alesp.py
@@ -71,6 +71,7 @@ class ALESPHandler(CasaLegislativa):
                 parlamentar.foto = deputado['urlFoto']
                 self.relatorio.parlamentar = parlamentar
                 return parlamentar
+        return None
     
     def obter_parlamentares(self):
         try:

--- a/legislei/houses/camara_deputados.py
+++ b/legislei/houses/camara_deputados.py
@@ -12,7 +12,8 @@ from legislei.models.relatorio import (Evento, Orgao, Parlamentar, Proposicao,
                                        Relatorio)
 from legislei.SDKs.CamaraDeputados.entidades import (Deputados, Eventos,
                                                      Proposicoes, Votacoes)
-from legislei.SDKs.CamaraDeputados.exceptions import CamaraDeputadosError
+from legislei.SDKs.CamaraDeputados.exceptions import (
+    CamaraDeputadosConnectionError, CamaraDeputadosError)
 
 
 class CamaraDeputadosHandler(CasaLegislativa):
@@ -360,7 +361,10 @@ class CamaraDeputadosHandler(CasaLegislativa):
         return deputados
 
     def obter_parlamentar(self, parlamentar_id):
-        deputado_info = self.dep.obterDeputado(parlamentar_id)
+        try:
+            deputado_info = self.dep.obterDeputado(parlamentar_id)
+        except CamaraDeputadosConnectionError:
+            return None
         parlamentar = Parlamentar()
         parlamentar.cargo = 'BR1'
         parlamentar.id = str(deputado_info['id'])

--- a/legislei/houses/camara_municipal_sao_paulo.py
+++ b/legislei/houses/camara_municipal_sao_paulo.py
@@ -134,6 +134,7 @@ class CamaraMunicipalSaoPauloHandler(CasaLegislativa):
                 self.obter_cargos_parlamentar(item['cargos'])
                 self.relatorio.parlamentar = parlamentar
                 return parlamentar
+        return None
 
     def obter_cargos_parlamentar(self, cargos):
         for cargo in cargos:

--- a/tests/unit/test_alesp.py
+++ b/tests/unit/test_alesp.py
@@ -44,6 +44,22 @@ class TestALESPHandler(unittest.TestCase):
         self.assertEqual(expected_response, actual_response.to_dict())
         mock.assert_no_pending_responses()
 
+    def test_obterDeputado_invalid_id(self):
+        mock = Mocker(self.dep.dep)
+        mock.add_response(
+            "obterTodosDeputados",
+            [
+                {'id': '12'},
+                {'id': '11'},
+                {'id': '14', 'nome': 'Teste', 'siglaPartido': 'PPP', 'urlFoto': 'foto'},
+            ]
+        )
+        
+        actual_response = self.dep.obter_parlamentar('28')
+
+        self.assertIsNone(actual_response)
+        mock.assert_no_pending_responses()
+
     def test_obterParlamentares(self):
         mock = Mocker(self.dep.dep)
         mock_response = [

--- a/tests/unit/test_camara_municipal_sao_paulo.py
+++ b/tests/unit/test_camara_municipal_sao_paulo.py
@@ -81,6 +81,26 @@ class TestCamaraMunicipalSaoPauloHandler(unittest.TestCase):
         self.assertEqual(self.cmsp.relatorio.parlamentar.partido, "TESTE")
         self.assertEqual(self.cmsp.relatorio.parlamentar.cargo, "SÃO PAULO")
 
+    @patch("legislei.SDKs.CamaraMunicipalSaoPaulo.base.CamaraMunicipal.obterVereadores")
+    def test_obter_parlamentar(self, mock_obterVereadores):
+        mock_obterVereadores.return_value = [
+            {'chave': '1'},
+            {
+                'chave': '2',
+                'nome': 'Fulana',
+                'cargos': [],
+                'mandatos': [
+                    {'fim': datetime(2020, 12, 31), 'partido': {'sigla': 'TESTE'}},
+                    {'fim': datetime(2018, 12, 31)},
+                ]
+            },
+            {'chave': '3'},
+        ]
+
+        actual_result = self.cmsp.obter_parlamentar('14')
+
+        self.assertIsNone(actual_result)
+
     def test_obter_cargos_parlamentar(self):
         cargos = [
             {'fim': datetime(2018, 12, 31)},


### PR DESCRIPTION
* Corrige rota `GET v1/parlamentares/{casa}/{parlamentar}` quando `parlamentar` é inválido (resolve #67).