### PR TITLE
v0.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,7 @@ services:
   - mongodb
 # command to run tests
 script:
-  - python run_tests.py
+  - coverage run run_tests.py
+# command to run after tests passed
+after_success:
+  bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://travis-ci.com/brosquinha/legislei.svg?branch=master)](https://travis-ci.com/brosquinha/legislei)
 ![Python 3.5+](https://img.shields.io/badge/python-3.5^-blue.svg)
 ![glp](https://img.shields.io/github/license/brosquinha/legislei.svg)
+[![codecov](https://codecov.io/gh/brosquinha/legislei/branch/master/graph/badge.svg)](https://codecov.io/gh/brosquinha/legislei)
 [![Documentation Status](https://readthedocs.org/projects/legislei/badge/?version=latest)](https://legislei.readthedocs.io/pt/latest/?badge=latest)
 # Legislei
 

--- a/legislei/app.py
+++ b/legislei/app.py
@@ -170,11 +170,11 @@ def obter_relatorio_por_id(id):
 @login_required
 def avaliacoes():
     email = current_user.email
+    parlamentares, intervalo = Inscricao().obter_minhas_inscricoes(email)
     try:
         cargo = request.args['parlamentarTipo']
         parlamentar = request.args['parlamentar']
     except KeyError:
-        parlamentares, intervalo = Inscricao().obter_minhas_inscricoes(email)
         return render_template(
             'avaliacoes_home.html',
             parlamentares=parlamentares,
@@ -182,11 +182,15 @@ def avaliacoes():
         )
     parlamentar_dados, avaliacoes_dados, nota = Avaliacao().avaliacoes(
         cargo, parlamentar, email)
+    try:
+        parlamentar_dados = next(p for p in parlamentares if p.id == parlamentar)
+    except StopIteration:
+        pass
     return render_template(
         'avaliacoes_parlamentar.html',
         parlamentar=parlamentar_dados,
         avaliacoes=avaliacoes_dados,
-        nota=nota
+        nota=nota if nota != None else 0
     ), 200
 
 

--- a/legislei/houses/alesp.py
+++ b/legislei/houses/alesp.py
@@ -71,6 +71,7 @@ class ALESPHandler(CasaLegislativa):
                 parlamentar.foto = deputado['urlFoto']
                 self.relatorio.parlamentar = parlamentar
                 return parlamentar
+        return None
     
     def obter_parlamentares(self):
         try:

--- a/legislei/houses/camara_deputados.py
+++ b/legislei/houses/camara_deputados.py
@@ -12,7 +12,8 @@ from legislei.models.relatorio import (Evento, Orgao, Parlamentar, Proposicao,
                                        Relatorio)
 from legislei.SDKs.CamaraDeputados.entidades import (Deputados, Eventos,
                                                      Proposicoes, Votacoes)
-from legislei.SDKs.CamaraDeputados.exceptions import CamaraDeputadosError
+from legislei.SDKs.CamaraDeputados.exceptions import (
+    CamaraDeputadosConnectionError, CamaraDeputadosError)
 
 
 class CamaraDeputadosHandler(CasaLegislativa):
@@ -360,7 +361,10 @@ class CamaraDeputadosHandler(CasaLegislativa):
         return deputados
 
     def obter_parlamentar(self, parlamentar_id):
-        deputado_info = self.dep.obterDeputado(parlamentar_id)
+        try:
+            deputado_info = self.dep.obterDeputado(parlamentar_id)
+        except CamaraDeputadosConnectionError:
+            return None
         parlamentar = Parlamentar()
         parlamentar.cargo = 'BR1'
         parlamentar.id = str(deputado_info['id'])

--- a/legislei/houses/camara_municipal_sao_paulo.py
+++ b/legislei/houses/camara_municipal_sao_paulo.py
@@ -134,6 +134,7 @@ class CamaraMunicipalSaoPauloHandler(CasaLegislativa):
                 self.obter_cargos_parlamentar(item['cargos'])
                 self.relatorio.parlamentar = parlamentar
                 return parlamentar
+        return None
 
     def obter_cargos_parlamentar(self, cargos):
         for cargo in cargos:

--- a/legislei/templates/avaliacoes_parlamentar.html
+++ b/legislei/templates/avaliacoes_parlamentar.html
@@ -50,16 +50,16 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-sm-3">Atividades que amei
+            <div class="col-sm-3">Atividades que amei ({{ avaliacoes['2']|length }})
                 {{ cards('2') }}
             </div>
-            <div class="col-sm-3">Atividades que aprovei
+            <div class="col-sm-3">Atividades que aprovei ({{ avaliacoes['1']|length }})
                 {{ cards('1') }}
             </div>
-            <div class="col-sm-3">Atividades que desaprovei
+            <div class="col-sm-3">Atividades que desaprovei ({{ avaliacoes['-1']|length }})
                 {{ cards('-1') }}
             </div>
-            <div class="col-sm-3">Atividades que detestei
+            <div class="col-sm-3">Atividades que detestei ({{ avaliacoes['-2']|length }})
                 {{ cards('-2') }}
             </div>
         </div>

--- a/run_tests.py
+++ b/run_tests.py
@@ -7,6 +7,7 @@ from tests.integration.test_camara_deputados import \
     TestCamaraDeputadosHandlerIntegration
 from tests.integration.test_camara_municipal_sao_paulo import \
     TestCamaraMunicipalSaoPauloHandlerIntegration
+from tests.integration.test_device_controller import TestDeviceController
 from tests.integration.test_house_controller import TestHouseController
 from tests.integration.test_report_controller import TestReportController
 from tests.integration.test_subscription_controller import TestSubscriptionController
@@ -18,6 +19,7 @@ from tests.unit.test_camara_municipal_sao_paulo import \
     TestCamaraMunicipalSaoPauloHandler
 from tests.unit.test_casa_legislativa import TestCasaLegislativa
 from tests.unit.test_cron import TestCron
+from tests.unit.test_dispositivos import TestDispositivos
 from tests.unit.test_dto import TestDTOs
 from tests.unit.test_inscricoes import TestInscricao
 from tests.unit.test_relatorios import TestRelatorios

--- a/tests/integration/test_app.py
+++ b/tests/integration/test_app.py
@@ -73,7 +73,33 @@ class TestApp(ControllerHelperTester):
         self.assertIn(b"ParlamentarTeste", actual.data)
         self.assertIn(b"Saldo total: 1", actual.data)
 
+    def test_minhas_avaliacoes_parlamentar_parlamentar_fora_inscricoes(self):
+        parlamentar = Parlamentar(
+            nome="ParlamentarTeste2",
+            id="1234",
+            cargo="BR1"
+        )
+        Avaliacoes(
+            email="test@email.com",
+            parlamentar=parlamentar,
+            avaliacao="-1",
+            avaliado={}
+        ).save()
+        login(self.app, "test", "123")
+        actual = self.app.get("/minhasAvaliacoes?parlamentarTipo=BR1&parlamentar=1234")
+        self.assertEqual(actual.status_code, 200)
+        self.assertIn(b"ParlamentarTeste2", actual.data)
+        self.assertIn(b"Saldo total: -1", actual.data)
+
     def test_minhas_avaliacoes_parlamentar_sem_avaliacoes(self):
+        Avaliacoes().drop_collection()
+        login(self.app, "test", "123")
+        actual = self.app.get("/minhasAvaliacoes?parlamentarTipo=BR1&parlamentar=123")
+        self.assertEqual(actual.status_code, 200)
+        self.assertIn(b"ParlamentarTeste", actual.data)
+        self.assertIn(b"Saldo total: 0", actual.data)
+    
+    def test_minhas_avaliacoes_parlamentar_sem_avaliacoes_parlamentar_fora_inscricoes(self):
         login(self.app, "test", "123")
         actual = self.app.get("/minhasAvaliacoes?parlamentarTipo=BR1&parlamentar=12345")
         self.assertEqual(actual.status_code, 200)

--- a/tests/unit/test_alesp.py
+++ b/tests/unit/test_alesp.py
@@ -44,6 +44,22 @@ class TestALESPHandler(unittest.TestCase):
         self.assertEqual(expected_response, actual_response.to_dict())
         mock.assert_no_pending_responses()
 
+    def test_obterDeputado_invalid_id(self):
+        mock = Mocker(self.dep.dep)
+        mock.add_response(
+            "obterTodosDeputados",
+            [
+                {'id': '12'},
+                {'id': '11'},
+                {'id': '14', 'nome': 'Teste', 'siglaPartido': 'PPP', 'urlFoto': 'foto'},
+            ]
+        )
+        
+        actual_response = self.dep.obter_parlamentar('28')
+
+        self.assertIsNone(actual_response)
+        mock.assert_no_pending_responses()
+
     def test_obterParlamentares(self):
         mock = Mocker(self.dep.dep)
         mock_response = [

--- a/tests/unit/test_avaliacoes.py
+++ b/tests/unit/test_avaliacoes.py
@@ -111,3 +111,12 @@ class TestAvaliacao(unittest.TestCase):
             '-2': []
         })
         self.assertEqual(actual[2], 9)
+
+    def test_avaliacoes_de_parlamentar_sem_avaliacoes(self):
+        parlamentar = Parlamentar(id='id', cargo='BR1')
+
+        actual = Avaliacao().avaliacoes('BR1', 'id', 'test@email.com')
+
+        self.assertIsNone(actual[0])
+        self.assertIsNone(actual[1])
+        self.assertIsNone(actual[2])

--- a/tests/unit/test_camara_municipal_sao_paulo.py
+++ b/tests/unit/test_camara_municipal_sao_paulo.py
@@ -81,6 +81,26 @@ class TestCamaraMunicipalSaoPauloHandler(unittest.TestCase):
         self.assertEqual(self.cmsp.relatorio.parlamentar.partido, "TESTE")
         self.assertEqual(self.cmsp.relatorio.parlamentar.cargo, "SÃO PAULO")
 
+    @patch("legislei.SDKs.CamaraMunicipalSaoPaulo.base.CamaraMunicipal.obterVereadores")
+    def test_obter_parlamentar(self, mock_obterVereadores):
+        mock_obterVereadores.return_value = [
+            {'chave': '1'},
+            {
+                'chave': '2',
+                'nome': 'Fulana',
+                'cargos': [],
+                'mandatos': [
+                    {'fim': datetime(2020, 12, 31), 'partido': {'sigla': 'TESTE'}},
+                    {'fim': datetime(2018, 12, 31)},
+                ]
+            },
+            {'chave': '3'},
+        ]
+
+        actual_result = self.cmsp.obter_parlamentar('14')
+
+        self.assertIsNone(actual_result)
+
     def test_obter_cargos_parlamentar(self):
         cargos = [
             {'fim': datetime(2018, 12, 31)},


### PR DESCRIPTION
Correções e melhorias:

* Corrige rota `GET v1/parlamentares/{casa}/{parlamentar}` quando `parlamentar` é inválido (resolve #67);
* Adiciona contadores de avaliações por categoria na página de minhas avaliações de parlamentar;
* Usa as informações de parlamentar a partir das inscrições de usuário na página de avaliações de parlamentar quando possível;
* Acrescenta configurações para relatório de cobertura de testes com [Codecov](https://codecov.io).