### PR TITLE
Add missing info to obter_parlamentes

### DIFF
--- a/legislei/houses/camara_deputados.py
+++ b/legislei/houses/camara_deputados.py
@@ -352,6 +352,7 @@ class CamaraDeputadosHandler(CasaLegislativa):
         for page in self.dep.obterTodosDeputados():
             for item in page:
                 parlamentar = Parlamentar()
+                parlamentar.cargo = 'BR1'
                 parlamentar.id = str(item['id'])
                 parlamentar.nome = item['nome']
                 parlamentar.partido = item['siglaPartido']

--- a/legislei/houses/camara_municipal_sao_paulo.py
+++ b/legislei/houses/camara_municipal_sao_paulo.py
@@ -157,7 +157,8 @@ class CamaraMunicipalSaoPauloHandler(CasaLegislativa):
                     nome=v['nome'],
                     partido=v['mandatos'][0]['partido']['sigla'],
                     uf='SP',
-                    cargo='SÃO PAULO'
+                    cargo='SÃO PAULO',
+                    foto='https://www.99luca11.com/Users/usuario_sem_foto.png'
                 )
             )
         return lista

--- a/tests/unit/test_camara_deputados.py
+++ b/tests/unit/test_camara_deputados.py
@@ -56,6 +56,7 @@ class TestCamaraDeputadosHandler(unittest.TestCase):
                 partido='P1',
                 uf='UF',
                 foto='foto',
+                cargo='BR1'
             ),
             Parlamentar(
                 nome='FULANO PESSOA',
@@ -63,6 +64,7 @@ class TestCamaraDeputadosHandler(unittest.TestCase):
                 partido='P2',
                 uf='UF',
                 foto='foto2',
+                cargo='BR1'
             ),
             Parlamentar(
                 nome='SICRANO PINTO',
@@ -70,6 +72,7 @@ class TestCamaraDeputadosHandler(unittest.TestCase):
                 partido='P1',
                 uf='UF2',
                 foto='foto3',
+                cargo='BR1'
             )
         ]
         mock = Mocker(self.dep.dep)

--- a/tests/unit/test_camara_municipal_sao_paulo.py
+++ b/tests/unit/test_camara_municipal_sao_paulo.py
@@ -152,7 +152,7 @@ class TestCamaraMunicipalSaoPauloHandler(unittest.TestCase):
         actual = self.cmsp.obter_parlamentares()
 
         self.assertEqual(actual, [
-            Parlamentar(**{'nome': 'Fulano', 'id': '1', 'partido': 'TESTE', 'uf': 'SP', 'cargo': 'SÃO PAULO'}),
-            Parlamentar(**{'nome': 'Fulana', 'id': '2', 'partido': 'TESTE', 'uf': 'SP', 'cargo': 'SÃO PAULO'}),
-            Parlamentar(**{'nome': 'Joana', 'id': '3', 'partido': 'TESTE', 'uf': 'SP', 'cargo': 'SÃO PAULO'})
+            Parlamentar(**{'nome': 'Fulano', 'id': '1', 'partido': 'TESTE', 'uf': 'SP', 'cargo': 'SÃO PAULO', 'foto': 'https://www.99luca11.com/Users/usuario_sem_foto.png'}),
+            Parlamentar(**{'nome': 'Fulana', 'id': '2', 'partido': 'TESTE', 'uf': 'SP', 'cargo': 'SÃO PAULO', 'foto': 'https://www.99luca11.com/Users/usuario_sem_foto.png'}),
+            Parlamentar(**{'nome': 'Joana', 'id': '3', 'partido': 'TESTE', 'uf': 'SP', 'cargo': 'SÃO PAULO', 'foto': 'https://www.99luca11.com/Users/usuario_sem_foto.png'})
         ])


### PR DESCRIPTION
* Acrescenta campos ausentes de algumas casas da rota `GET /v1/parlamentares/{casa}`.